### PR TITLE
fix php extesnion and CI DB config

### DIFF
--- a/.bp-config/options.json
+++ b/.bp-config/options.json
@@ -1,0 +1,4 @@
+{
+    "ADMIN_EMAIL": "dan@mikusa.com",
+    "PHP_EXTENSIONS": ["mbstring", "mysql", "mysqli", "mcrypt", "gd", "zip"]
+}

--- a/application/config/database.php
+++ b/application/config/database.php
@@ -46,29 +46,82 @@
 */
 
 // Look for bound MySQL Services, pick the first one
-$services = json_decode($_ENV['VCAP_SERVICES'], true);
-$service = $services['cleardb'][0];
+//$services = json_decode($_ENV['VCAP_SERVICES'], true);
+//$service = $services['cleardb'][0];
+
+// Look for bound MySQL Services
+$service_blob = json_decode($_ENV['VCAP_SERVICES'], true);
+$mysql_services = array();
+foreach($service_blob as $service_provider => $service_list) {
+    // looks for 'cleardb' or 'p-mysql' service
+    if ($service_provider === 'cleardb' || $service_provider === 'p-mysql') {
+        foreach($service_list as $mysql_service) {
+            $mysql_services[] = $mysql_service;
+        }
+        continue;
+    }
+    foreach ($service_list as $some_service) {
+        // looks for tags of 'mysql'
+        if (in_array('mysql', $some_service['tags'], true)) {
+            $mysql_services[] = $some_service;
+            continue;
+        }
+        // look for a service where the name includes 'mysql'
+        if (strpos($some_service['name'], 'mysql') !== false) {
+            $mysql_services[] = $some_service;
+        }
+    }
+}
+
+/*
+ * Servers configuration
+ */
+for ($i = 0; $i < count($mysql_services); $i++) {	
+		$service_name = $mysql_services[$i]['name'];		//your service name
+    $credentials = $mysql_services[$i]['credentials'];
+	
+		$db[$service_name]['hostname'] = $credentials['hostname'];
+		$db[$service_name]['port'] 		= $credentials['port'];
+		$db[$service_name]['username'] = $credentials['username'];
+		$db[$service_name]['password'] = $credentials['password'];
+		$db[$service_name]['database'] = $credentials['name'];
+		$db[$service_name]['dbdriver'] = 'mysql';
+		$db[$service_name]['dbprefix'] = 'CI_';
+		$db[$service_name]['pconnect'] = TRUE;
+		$db[$service_name]['db_debug'] = TRUE;
+		$db[$service_name]['cache_on'] = FALSE;
+		$db[$service_name]['cachedir'] = '';
+		$db[$service_name]['char_set'] = 'utf8';
+		$db[$service_name]['dbcollat'] = 'utf8_general_ci';
+		$db[$service_name]['swap_pre'] = '';
+		$db[$service_name]['autoinit'] = TRUE;
+		$db[$service_name]['stricton'] = FALSE;
+	
+		//pick the first one as default
+		if($i == 0) {
+			$db['default'] = $db[$service_name];
+		}
+}
 
 $active_group = 'default';
 $active_record = TRUE;
 
-$db['default']['hostname'] = $service['credentials']['hostname'];
-$db['default']['port'] = $service['credentials']['port'];
-$db['default']['username'] = $service['credentials']['username'];
-$db['default']['password'] = $service['credentials']['password'];
-$db['default']['database'] = $service['credentials']['name'];
-$db['default']['dbdriver'] = 'mysql';
-$db['default']['dbprefix'] = 'CI_';
-$db['default']['pconnect'] = TRUE;
-$db['default']['db_debug'] = TRUE;
-$db['default']['cache_on'] = FALSE;
-$db['default']['cachedir'] = '';
-$db['default']['char_set'] = 'utf8';
-$db['default']['dbcollat'] = 'utf8_general_ci';
-$db['default']['swap_pre'] = '';
-$db['default']['autoinit'] = TRUE;
-$db['default']['stricton'] = FALSE;
-
+//$db['default']['hostname'] = $service['credentials']['hostname'];
+//$db['default']['port'] = $service['credentials']['port'];
+//$db['default']['username'] = $service['credentials']['username'];
+//$db['default']['password'] = $service['credentials']['password'];
+//$db['default']['database'] = $service['credentials']['name'];
+//$db['default']['dbdriver'] = 'mysql';
+//$db['default']['dbprefix'] = 'CI_';
+//$db['default']['pconnect'] = TRUE;
+//$db['default']['db_debug'] = TRUE;
+//$db['default']['cache_on'] = FALSE;
+//$db['default']['cachedir'] = '';
+//$db['default']['char_set'] = 'utf8';
+//$db['default']['dbcollat'] = 'utf8_general_ci';
+//$db['default']['swap_pre'] = '';
+//$db['default']['autoinit'] = TRUE;
+//$db['default']['stricton'] = FALSE;
 
 /* End of file database.php */
 /* Location: ./application/config/database.php */


### PR DESCRIPTION
add options.json under .bp/config to enable php extension such as mysql
enhance application/config/database.php for handling different provider of mysql settings, e.g, clearDB or mysql
